### PR TITLE
Packaging fixes

### DIFF
--- a/evil-briefcase-mode.el
+++ b/evil-briefcase-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: Aaron Strick <aaronstrick@gmail.com>
 ;; Version: 0.0.1
+;; Package-Requires: ((evil "1.2.13") (s "1.12.0"))
 ;; Keywords: strings, evil
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/evil-briefcase-mode.el
+++ b/evil-briefcase-mode.el
@@ -26,9 +26,9 @@
 
 ;;; Code:
 
-(use-package evil-macros)
-(use-package evil-core)
-(use-package s)
+(require 'evil-macros)
+(require 'evil-core)
+(require 's)
 
 (evil-define-operator evil-briefcase-camel-upper (beg end type)
   "Convert text to CamelCase with a Capital C"

--- a/evil-briefcase.el
+++ b/evil-briefcase.el
@@ -106,5 +106,5 @@
   :lighter " evil-briefcase"
   )
 
-(provide 'evil-briefcase-mode)
+(provide 'evil-briefcase)
 ;;; evil-briefcase.el ends here


### PR DESCRIPTION
Using `require` is the right way. (1. Not everyone uses use-package. 2. Using use-package would mean an unnecessary dependency on use-package for those who don't use it. 3. use-package is more supposed to only be for a user's personal init file, I think.)

The `Package-Requires:` line is a package.el convention (I think) for specifying dependencies for a package so that they are installed when installing the package, so that the `require`s work. I don't know what versions of evil and s.el you are using so I just went with the latest releases.

Let me know if you have any questions/concerns or need any further clarification.