### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In your .spacemacs file (`SPC f e d`):
 
 dotspacemacs-additional-packages
 '(
-  (evil-briefcase :location (recipe :fetcher github :repo "strickinato/evil-briefcase"))
+  (evil-briefcase-mode :location (recipe :fetcher github :repo "strickinato/evil-briefcase"))
 )
 
 ```


### PR DESCRIPTION
This fixes the following installation error:

> An error occurred while installing evil-briefcase
> (error: (error Single file evil-briefcase-mode.el
>   does not match package name evil-briefcase))